### PR TITLE
Cleanup: fix typo and rename the kolecontroller struct

### DIFF
--- a/pkg/data/heartbeat.go
+++ b/pkg/data/heartbeat.go
@@ -20,34 +20,32 @@ import (
 	"fmt"
 )
 
-const HeatBeatRegistering = "Registering"
-const HeatBeatRegisterd = "Registerd"
-const HeatBeatOffline = "Offline"
+const HeartBeatRegistering = "Registering"
+const HeartBeatRegisterd = "Registerd"
+const HeartBeatOffline = "Offline"
 
 const OFFLINE_TIMEOUT = 60 * 20
 
-type HeatBeat struct {
-	Name string `json:"name,omitempty"`
-	// 未来可能用于workload 的label selector
+type HeartBeat struct {
+	Name      string            `json:"name,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty"`
 	TimeStamp int64             `json:"timestamp,omitempty"`
-	// 仅用于云端控制器记录上一次收到的时间戳记录，用于判断是否超时
-	LasterTimeStamp int64           `json:"-"`
-	Identifier      string          `json:"identifier,omitempty"`
-	SeqNum          uint64          `json:"seqnum,omitempty"`
-	State           string          `json:"state,omitempty"`
-	Status          *HeatBeatStatus `json:"status,omitempty"`
-	Pods            []*HeatBeatPod  `json:"pods,omitempty"`
+	// Used in cloud state cache only
+	LasterTimeStamp int64            `json:"-"`
+	Identifier      string           `json:"identifier,omitempty"`
+	SeqNum          uint64           `json:"seqnum,omitempty"`
+	State           string           `json:"state,omitempty"`
+	Status          *HeartBeatStatus `json:"status,omitempty"`
+	Pods            []*HeartBeatPod  `json:"pods,omitempty"`
 }
 
-type HeatBeatStatus struct {
-	// IP地址
+type HeartBeatStatus struct {
+	// IP
 	Addresses []*Address `json:"addresses,omitempty"`
-	// 可分配的资源， 便于云端控制器调度
+	// Resources that can be used by cloud scheduler
 	Allocatable *Resource `json:"allocatable,omitempty"`
-	// 容量
-	Capacity *Resource `json:"capacity,omitempty"`
-	NodeInfo *NodeInfo `json:"nodeInfo,omitempty"`
+	Capacity    *Resource `json:"capacity,omitempty"`
+	NodeInfo    *NodeInfo `json:"nodeInfo,omitempty"`
 }
 
 const AddressTypeInternal = "InternalIP"
@@ -73,28 +71,27 @@ type NodeInfo struct {
 	KernelVersion      string
 }
 
-type HeatBeatPod struct {
-	// 只需要上报它的hash 值， 这样方便云端控制器 根据workload 判断是否要重新下发新的配置
-	// 不需要上传pod 的具体spec 信息
-	Hash      string             `json:"hash,omitempty"`
-	Name      string             `json:"name,omitempty"`
-	NameSpace string             `json:"namespace,omitempty"`
-	Status    *HeatBeatPodStatus `json:"status,omitempty"`
+type HeartBeatPod struct {
+	// We only report the hash of the Pod Spec in the edge node to compare against the spec in the cloud state cache.
+	Hash      string              `json:"hash,omitempty"`
+	Name      string              `json:"name,omitempty"`
+	NameSpace string              `json:"namespace,omitempty"`
+	Status    *HeartBeatPodStatus `json:"status,omitempty"`
 }
 
-func (p *HeatBeatPod) Key() string {
+func (p *HeartBeatPod) Key() string {
 	return fmt.Sprintf("%s-%s", p.NameSpace, p.Name)
 }
 
-const HeatBeatPodStatusRunning = "Running"
+const HeartBeatPodStatusRunning = "Running"
 
-type HeatBeatPodStatus struct {
+type HeartBeatPodStatus struct {
 	// Runing ,Completed, Termaled ...
 	Phase string `json:"phase,omitempty"`
 }
 
-func UnmarshalPayloadToHeatBeat(payload []byte) (*HeatBeat, error) {
-	d := &HeatBeat{}
+func UnmarshalPayloadToHeartBeat(payload []byte) (*HeartBeat, error) {
+	d := &HeartBeat{}
 	if err := json.Unmarshal(payload, d); err != nil {
 		return nil, err
 	}

--- a/pkg/data/heartbeat_ack.go
+++ b/pkg/data/heartbeat_ack.go
@@ -19,14 +19,14 @@ import (
 	"encoding/json"
 )
 
-type HeatBeatACK struct {
+type HeartBeatACK struct {
 	Identifier string `json:"identifier,omitempty"`
 	Registerd  bool   `json:"registerd,omitempty"`
 	NodeName   string `json:"-"`
 }
 
-func UnmarshalPayloadToHeatBeatACK(payload []byte) (*HeatBeatACK, error) {
-	d := &HeatBeatACK{}
+func UnmarshalPayloadToHeartBeatACK(payload []byte) (*HeartBeatACK, error) {
+	d := &HeartBeatACK{}
 	if err := json.Unmarshal(payload, d); err != nil {
 		return nil, err
 	}

--- a/pkg/kolecontroller/consumeHeartBeat.go
+++ b/pkg/kolecontroller/consumeHeartBeat.go
@@ -26,9 +26,9 @@ import (
 	"github.com/openyurtio/kole/pkg/util"
 )
 
-func (c *InfEdgeController) ConsumeHeatBeatDirect(hb *data.HeatBeat) {
+func (c *KoleController) ConsumeHeartBeatDirect(hb *data.HeartBeat) {
 
-	sync_pods := c.ConsumeSingleHeatBeat(hb)
+	sync_pods := c.ConsumeSingleHeartBeat(hb)
 
 	dataTopic := filepath.Join(util.TopicDataPrefix, hb.Name)
 
@@ -42,18 +42,17 @@ func (c *InfEdgeController) ConsumeHeatBeatDirect(hb *data.HeatBeat) {
 	}(dataTopic, sync_pods)
 }
 
-func (c *InfEdgeController) ConsumeSingleHeatBeat(hb *data.HeatBeat) []*data.Pod {
+func (c *KoleController) ConsumeSingleHeartBeat(hb *data.HeartBeat) []*data.Pod {
 	c.ReceiveNum++
 
-	klog.V(5).Infof("Receive heatbeat Indentifier[%s] Name[%s] State[%s]", hb.Identifier, hb.Name, hb.State)
+	klog.V(5).Infof("Received heatbeat Indentifier[%s] Name[%s] State[%s]", hb.Identifier, hb.Name, hb.State)
 
-	if !c.HeatBeatFilter.SetHeatBeat(hb) {
+	if !c.HeartBeatFilter.SetHeartBeat(hb) {
 		return []*data.Pod{}
 	}
 
-	c.ObserverdPodsCache.SafeSetHeatBeat(hb)
+	c.ObserverdPodsCache.SafeSetHeartBeat(hb)
 
-	// 获得的与期望的比较
 	sync_pods := make([]*data.Pod, 0, 20)
 
 	c.DesiredPodsCache.SafeOperate(func() {
@@ -95,7 +94,7 @@ func (c *InfEdgeController) ConsumeSingleHeatBeat(hb *data.HeatBeat) []*data.Pod
 		}
 	})
 
-	c.HeatBeatCache.ReceiveHeatBeat(hb, c.InfDaemonSetController)
+	c.HeartBeatCache.ReceiveHeartBeat(hb, c.InfDaemonSetController)
 
 	return sync_pods
 }

--- a/pkg/kolecontroller/consumeHeartBeat_test.go
+++ b/pkg/kolecontroller/consumeHeartBeat_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/openyurtio/kole/pkg/util"
 )
 
-func TestConsumeHeatBeat(t *testing.T) {
+func TestConsumeHeartBeat(t *testing.T) {
 	stop := make(chan struct{}, 1)
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -50,25 +50,24 @@ func TestConsumeHeatBeat(t *testing.T) {
 	// set rate limit
 	c.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(10000, 10000)
 
-	// 实例化clientset对象
 	crdclient, err := versioned.NewForConfig(c)
 	if err != nil {
 		t.Fatalf("Build versioned config error %v", err)
 	}
 
-	infedge := &InfEdgeController{
-		HeatBeatCache: &HeatBeatCache{
+	koleInstance := &KoleController{
+		HeartBeatCache: &HeartBeatCache{
 			RWMutex: &sync.RWMutex{},
-			Cache:   make(map[string]*data.HeatBeat),
+			Cache:   make(map[string]*data.HeartBeat),
 		},
-		HeatBeatFilter: &HeatBeatFilter{
+		HeartBeatFilter: &HeartBeatFilter{
 			Mutex:  &sync.Mutex{},
 			Filter: make(map[string]*FilterInfo),
 		},
 
 		ObserverdPodsCache: &ObserverdPodsCache{
 			RWMutex: &sync.RWMutex{},
-			Cache:   make(map[string]map[string]*data.HeatBeatPod),
+			Cache:   make(map[string]map[string]*data.HeartBeatPod),
 		},
 		QueryNodeStatusCache: &QueryNodeStatusCache{
 			RWMutex:      &sync.RWMutex{},
@@ -92,15 +91,15 @@ func TestConsumeHeatBeat(t *testing.T) {
 
 	go controller.Run(5, stop)
 
-	infedge.InfDaemonSetController = controller
+	koleInstance.InfDaemonSetController = controller
 
-	hb := util.InitMockHeatBeat("", 1)
+	hb := util.InitMockHeartBeat("", 1)
 
 	for i := 1; i <= 10; i++ {
 		n := time.Now()
 		for j := 0; j < 100000; j++ {
 			hb.Name = fmt.Sprintf("%d-%d", i, j)
-			infedge.ConsumeSingleHeatBeat(hb)
+			koleInstance.ConsumeSingleHeartBeat(hb)
 		}
 		t.Logf("%d0w use %d ms", i, time.Now().Sub(n).Milliseconds())
 	}

--- a/pkg/kolecontroller/kole_controller_heatbeatcache.go
+++ b/pkg/kolecontroller/kole_controller_heatbeatcache.go
@@ -23,25 +23,25 @@ import (
 	"github.com/openyurtio/kole/pkg/data"
 )
 
-type HeatBeatCache struct {
+type HeartBeatCache struct {
 	*sync.RWMutex
-	Cache map[string]*data.HeatBeat
+	Cache map[string]*data.HeartBeat
 }
 
-func (c *HeatBeatCache) SafeReadOperate(f func()) {
+func (c *HeartBeatCache) SafeReadOperate(f func()) {
 	c.RLock()
 	f()
 	c.RUnlock()
 }
 
-func (c *HeatBeatCache) ReceiveHeatBeat(hb *data.HeatBeat, daemonSetCtl *InfDaemonSetController) *data.HeatBeatACK {
+func (c *HeartBeatCache) ReceiveHeartBeat(hb *data.HeartBeat, daemonSetCtl *InfDaemonSetController) *data.HeartBeatACK {
 	n := time.Now().Unix()
-	var ack *data.HeatBeatACK
+	var ack *data.HeartBeatACK
 
 	c.Lock()
 
-	if hb.State == data.HeatBeatRegistering {
-		//hb.State = data.HeatBeatRegisterd
+	if hb.State == data.HeartBeatRegistering {
+		//hb.State = data.HeartBeatRegisterd
 		daemonSetCtl.AddHost(hb.Name)
 	}
 

--- a/pkg/kolecontroller/kole_controller_heatbeatfilter.go
+++ b/pkg/kolecontroller/kole_controller_heatbeatfilter.go
@@ -29,22 +29,22 @@ type FilterInfo struct {
 	TimeStamp int64
 }
 
-type HeatBeatFilter struct {
+type HeartBeatFilter struct {
 	*sync.Mutex
 	Filter map[string]*FilterInfo
 }
 
-func (c *HeatBeatFilter) SetHeatBeat(hb *data.HeatBeat) bool {
+func (c *HeartBeatFilter) SetHeartBeat(hb *data.HeartBeat) bool {
 	c.Lock()
 	setSuccess := true
 
 	old, ok := c.Filter[hb.Name]
 	if ok {
 		if hb.SeqNum < old.SeqNum {
-			klog.Warningf("Receive HeatBeat Node %s Seq %v is less then cache seq %v, do nothing", hb.Name, hb.SeqNum, old.SeqNum)
+			klog.Warningf("Received heartbeat from %s, seq %v is less then cached seq %v, skip", hb.Name, hb.SeqNum, old.SeqNum)
 			setSuccess = false
 		} else if hb.SeqNum == old.SeqNum && hb.TimeStamp <= old.TimeStamp {
-			klog.V(4).Infof("Receive HeatBeat Node %s Seq %v equal cache seq, but timestamp[%v] is less or equal than cache[%v], do nothing", hb.Name, hb.SeqNum,
+			klog.V(4).Infof("Received heatbeat from %s, seq %v is equal to the cached seq, but the timestamp[%v] older than the cached value [%v], skip", hb.Name, hb.SeqNum,
 				hb.TimeStamp, old.TimeStamp)
 			setSuccess = false
 		}

--- a/pkg/kolecontroller/kole_controller_observerdpodcache.go
+++ b/pkg/kolecontroller/kole_controller_observerdpodcache.go
@@ -25,17 +25,17 @@ import (
 type ObserverdPodsCache struct {
 	*sync.RWMutex
 	// nodeName / pod key / Pod
-	Cache map[string]map[string]*data.HeatBeatPod
+	Cache map[string]map[string]*data.HeartBeatPod
 }
 
-func (c *ObserverdPodsCache) SafeSetHeatBeat(hb *data.HeatBeat) {
+func (c *ObserverdPodsCache) SafeSetHeartBeat(hb *data.HeartBeat) {
 	c.Lock()
 	_, ok := c.Cache[hb.Name]
 	if !ok {
-		c.Cache[hb.Name] = make(map[string]*data.HeatBeatPod)
+		c.Cache[hb.Name] = make(map[string]*data.HeartBeatPod)
 	}
 	for _, hbp := range hb.Pods {
-		c.Cache[hb.Name][hbp.Key()] = &data.HeatBeatPod{
+		c.Cache[hb.Name][hbp.Key()] = &data.HeartBeatPod{
 			Hash:      hbp.Hash,
 			Name:      hbp.Name,
 			NameSpace: hbp.NameSpace,
@@ -44,7 +44,7 @@ func (c *ObserverdPodsCache) SafeSetHeatBeat(hb *data.HeatBeat) {
 	}
 	c.Unlock()
 }
-func (c *ObserverdPodsCache) ReadRange(f func(nodeName string, hbPodList map[string]*data.HeatBeatPod)) {
+func (c *ObserverdPodsCache) ReadRange(f func(nodeName string, hbPodList map[string]*data.HeartBeatPod)) {
 	c.RLock()
 	for nodeName, _ := range c.Cache {
 		f(nodeName, c.Cache[nodeName])

--- a/pkg/kolecontroller/sub.go
+++ b/pkg/kolecontroller/sub.go
@@ -22,15 +22,12 @@ import (
 	"github.com/openyurtio/kole/pkg/data"
 )
 
-func (c *InfEdgeController) Mqtt3SubEdgeHeatBeat(client outmqtt.Client, message outmqtt.Message) {
-	//go func(message outmqtt.Message) {
-	hb, err := data.UnmarshalPayloadToHeatBeat(message.Payload())
+func (c *KoleController) Mqtt3SubEdgeHeartBeat(client outmqtt.Client, message outmqtt.Message) {
+	hb, err := data.UnmarshalPayloadToHeartBeat(message.Payload())
 	if err != nil {
-		klog.Errorf("UnmarshalPayloadToHeatBeat error %v", err)
+		klog.Errorf("UnmarshalPayloadToHeartBeat error %v", err)
 		return
 	}
-	c.ConsumeHeatBeatDirect(hb)
-	//c.HeatBeatQueue <- hb
+	c.ConsumeHeartBeatDirect(hb)
 	klog.V(5).Infof("sub heatbeat topic %s Name %s State %s", message.Topic(), hb.Name, hb.State)
-	//}(mes)
 }

--- a/pkg/kolecontroller/sub5.go
+++ b/pkg/kolecontroller/sub5.go
@@ -24,22 +24,22 @@ import (
 	"github.com/openyurtio/kole/pkg/util"
 )
 
-func (c *InfEdgeController) Mqtt5CreateSubscribes() []*message.SingleSubcribe {
+func (c *KoleController) Mqtt5CreateSubscribes() []*message.SingleSubcribe {
 
 	subs := make([]*message.SingleSubcribe, 0, 2)
 	//HB
 	subs = append(subs, &message.SingleSubcribe{
-		Topic: util.TopicHeatbeat,
+		Topic: util.TopicHeartBeat,
 		Option: paho.SubscribeOptions{
 			QoS: 1,
 		},
 		Handler: func(publish *paho.Publish) {
-			hb, err := data.UnmarshalPayloadToHeatBeat(publish.Payload)
+			hb, err := data.UnmarshalPayloadToHeartBeat(publish.Payload)
 			if err != nil {
-				klog.Errorf("UnmarshalPayloadToHeatBeat error %v", err)
+				klog.Errorf("UnmarshalPayloadToHeartBeat error %v", err)
 				return
 			}
-			c.ConsumeHeatBeatDirect(hb)
+			c.ConsumeHeartBeatDirect(hb)
 			klog.V(5).Infof("sub heatbeat topic %s Name %s State %s", publish.Topic, hb.Name, hb.State)
 		},
 	})

--- a/pkg/litekubelet/litekubelet.go
+++ b/pkg/litekubelet/litekubelet.go
@@ -113,11 +113,11 @@ func NewMainLiteKubelet(deps *options.LiteKubeletFlags, index int, ismqtt5 bool)
 }
 
 func (l *LiteKubelet) runRealyLoop() {
-	var hb *data.HeatBeat
+	var hb *data.HeartBeat
 	var err error
 
 	for {
-		hb, err = l.registeringHeatBeat(true)
+		hb, err = l.registeringHeartBeat(true)
 		if err != nil {
 			klog.Errorf("%s Registering heatbeat error %v", l.HostnameOverride, err)
 			time.Sleep(time.Second * 10)
@@ -127,7 +127,7 @@ func (l *LiteKubelet) runRealyLoop() {
 	}
 	l.Registerd = true
 
-	l.registerdHeatBeatLoop(hb)
+	l.registerdHeartBeatLoop(hb)
 }
 
 func (l *LiteKubelet) Run() {

--- a/pkg/litekubelet/sub.go
+++ b/pkg/litekubelet/sub.go
@@ -49,7 +49,7 @@ func (c *LiteKubelet) RegisterAndSubscribeTopic() error {
 }
 
 func (c *LiteKubelet) SubCTL(client outmqtt.Client, message outmqtt.Message) {
-	ack, err := data.UnmarshalPayloadToHeatBeatACK(message.Payload())
+	ack, err := data.UnmarshalPayloadToHeartBeatACK(message.Payload())
 	if err != nil {
 		klog.Errorf("Unmarshalpayload to headbeatack error %v", err)
 		return

--- a/pkg/litekubelet/sub5.go
+++ b/pkg/litekubelet/sub5.go
@@ -58,7 +58,7 @@ func (c *LiteKubelet) ConsumeSubLoop() {
 	// CTL
 	go func() {
 		for p := range c.Sub5CtlChan {
-			ack, err := data.UnmarshalPayloadToHeatBeatACK(p.Payload)
+			ack, err := data.UnmarshalPayloadToHeartBeatACK(p.Payload)
 			if err != nil {
 				klog.Errorf("Unmarshalpayload to headbeatack error %v", err)
 				return

--- a/pkg/stormtest/compression.go
+++ b/pkg/stormtest/compression.go
@@ -217,10 +217,10 @@ func (n *Compression) DeleteSummariesByNS(ns string) error {
 	return nil
 }
 
-// ProcessHeatBeatMap  only just simulates how to deal with heatBeatCache without doing anything meaningful
-func ProcessHeatBeatMap(heatBeatCache map[string]*data.HeatBeat) {
+// ProcessHeartBeatMap  only just simulates how to deal with heatBeatCache without doing anything meaningful
+func ProcessHeartBeatMap(heatBeatCache map[string]*data.HeartBeat) {
 	heatBeatFilter := make(map[string]*kolecontroller.FilterInfo)
-	observerdPods := make(map[string]map[string]*data.HeatBeatPod)
+	observerdPods := make(map[string]map[string]*data.HeartBeatPod)
 	nodeStatus := make(map[string]*v1alpha1.QueryNodeStatus)
 
 	for i, hb := range heatBeatCache {
@@ -232,9 +232,9 @@ func ProcessHeatBeatMap(heatBeatCache map[string]*data.HeatBeat) {
 			Status:          hb.State,
 			InfEdgeNodeName: hb.Name,
 		}
-		observerdPods[hb.Name] = make(map[string]*data.HeatBeatPod)
+		observerdPods[hb.Name] = make(map[string]*data.HeartBeatPod)
 		for _, hbp := range hb.Pods {
-			observerdPods[hb.Name][hbp.Key()] = &data.HeatBeatPod{
+			observerdPods[hb.Name][hbp.Key()] = &data.HeartBeatPod{
 				Hash:      hbp.Hash,
 				Name:      hbp.Name,
 				NameSpace: hbp.NameSpace,
@@ -273,7 +273,7 @@ func (n *Compression) Run() error {
 	}
 
 	now = time.Now()
-	heatBeatCache := make(map[string]*data.HeatBeat)
+	heatBeatCache := make(map[string]*data.HeartBeat)
 	cachedata, err := n.LoadSummariesByNs(n.DstNs)
 	if err != nil {
 		klog.Errorf("List cr in DstNs namespace fail: %v", err)
@@ -283,7 +283,7 @@ func (n *Compression) Run() error {
 		klog.Errorf("unmarshal error %v", err)
 		return err
 	}
-	ProcessHeatBeatMap(heatBeatCache)
+	ProcessHeartBeatMap(heatBeatCache)
 	needTime = time.Now().Sub(now).Milliseconds()
 	klog.Infof("[No Compress] Load all summaries from %s ns , datalen %d use %d ms", n.DstNs, len(cachedata), needTime)
 
@@ -335,12 +335,12 @@ func (n *Compression) Run() error {
 		return err
 	}
 
-	heatBeatCache = make(map[string]*data.HeatBeat)
+	heatBeatCache = make(map[string]*data.HeartBeat)
 	if err = json.Unmarshal(uncmp, &heatBeatCache); err != nil {
 		klog.Errorf("unmarshal error %v", err)
 		return err
 	}
-	ProcessHeatBeatMap(heatBeatCache)
+	ProcessHeartBeatMap(heatBeatCache)
 	needTime = time.Now().Sub(now).Milliseconds()
 	klog.Infof("[Algthm %s] Uncompress load cache from %s namespace use %d ms",
 		n.Algthm,

--- a/pkg/stormtest/consume_mqtt.go
+++ b/pkg/stormtest/consume_mqtt.go
@@ -57,9 +57,9 @@ func NewConsumeMqtt(config *options.ConsumeMqttFlags) (*ConsumeMqtt, error) {
 }
 
 func (n *ConsumeMqtt) testSub(client outmqtt.Client, message outmqtt.Message) {
-	hb, err := data.UnmarshalPayloadToHeatBeat(message.Payload())
+	hb, err := data.UnmarshalPayloadToHeartBeat(message.Payload())
 	if err != nil {
-		klog.Errorf("UnmarshalPayloadToHeatBeat error %v", err)
+		klog.Errorf("UnmarshalPayloadToHeartBeat error %v", err)
 		return
 	}
 	klog.Infof("Receive Message %s", hb.Name)

--- a/pkg/stormtest/consume_rocketmq.go
+++ b/pkg/stormtest/consume_rocketmq.go
@@ -66,9 +66,9 @@ func NewConsumeRocketMQ(config *options.RocketMQFlags) (*ConsumeRocketMQ, error)
 }
 
 func (n *ConsumeRocketMQ) ComsumeRocketMq(message string) {
-	hb, err := data.UnmarshalPayloadToHeatBeat([]byte(message))
+	hb, err := data.UnmarshalPayloadToHeartBeat([]byte(message))
 	if err != nil {
-		klog.Errorf("UnmarshalPayloadToHeatBeat error %v", err)
+		klog.Errorf("UnmarshalPayloadToHeartBeat error %v", err)
 		return
 	}
 	klog.Infof("Receive Message %s", hb.Name)

--- a/pkg/stormtest/create_mqtt_messages.go
+++ b/pkg/stormtest/create_mqtt_messages.go
@@ -66,15 +66,15 @@ func NewCreateMqttMessage(config *options.CreateMqttMessageFlags) (*CreateMqttMe
 	return t, nil
 }
 
-func initHeatBeat() *data.HeatBeat {
+func initHeartBeat() *data.HeartBeat {
 	labels := make(map[string]string)
 	labels["HostName"] = "testtttttttttttttttttt"
 
-	beat := &data.HeatBeat{
+	beat := &data.HeartBeat{
 		SeqNum:     0,
 		TimeStamp:  time.Now().Unix(),
 		Identifier: fmt.Sprintf("%v", uuid.New()),
-		State:      data.HeatBeatRegistering,
+		State:      data.HeartBeatRegistering,
 		Name:       "testtttttttttttttttttt",
 		Labels:     labels,
 	}
@@ -83,7 +83,7 @@ func initHeatBeat() *data.HeatBeat {
 }
 
 func (n *CreateMqttMessages) Run() error {
-	hb := initHeatBeat()
+	hb := initHeartBeat()
 
 	send := func(i int) error {
 		hb.Name = fmt.Sprintf("name-%d", i)

--- a/pkg/util/heartbeat.go
+++ b/pkg/util/heartbeat.go
@@ -24,18 +24,18 @@ import (
 	"github.com/openyurtio/kole/pkg/data"
 )
 
-func InitMockHeatBeat(hostname string, seqNum uint64) *data.HeatBeat {
+func InitMockHeartBeat(hostname string, seqNum uint64) *data.HeartBeat {
 	labels := make(map[string]string)
 	labels["HostName"] = hostname
 
-	return &data.HeatBeat{
+	return &data.HeartBeat{
 		SeqNum:     seqNum,
 		TimeStamp:  time.Now().Unix(),
 		Identifier: fmt.Sprintf("%v", uuid.New()),
-		State:      data.HeatBeatRegistering,
+		State:      data.HeartBeatRegistering,
 		Name:       hostname,
 		Labels:     labels,
-		Status: &data.HeatBeatStatus{
+		Status: &data.HeartBeatStatus{
 			Addresses: []*data.Address{
 				{
 					Address: "127.0.0.1",

--- a/pkg/util/topic.go
+++ b/pkg/util/topic.go
@@ -21,12 +21,12 @@ import (
 
 const TopicRoot = "kole/lite"
 
-var TopicHeatbeat string
+var TopicHeartBeat string
 var TopicCTLPrefix string
 var TopicDataPrefix string
 
 func init() {
-	TopicHeatbeat = filepath.Join(TopicRoot, "HEATBEAT")
+	TopicHeartBeat = filepath.Join(TopicRoot, "HEARTBEAT")
 	TopicCTLPrefix = filepath.Join(TopicRoot, "CTL")
 	TopicDataPrefix = filepath.Join(TopicRoot, "DATA")
 }


### PR DESCRIPTION
This change mainly does the following:
1) Rename InfEdgeController to KoleController;
2) Fix typo: HeatBeat -> HeartBeat anywhere;


Test:
Run `make`